### PR TITLE
refactor: add janitor based cache cleanup

### DIFF
--- a/pkg/cache/lru_test.go
+++ b/pkg/cache/lru_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestLRU(t *testing.T) {
-	lru := NewLRUCache[int](2, logger.New(logger.LevelInfo))
+	lru := NewLRUCache[int](2, 1*time.Second, logger.New(logger.LevelInfo))
 	lru.Set("a", 1, time.Second*2)
 	lru.Set("b", 2, time.Second*2)
 	val, ok := lru.Get("a")
@@ -31,7 +31,7 @@ func TestLRU(t *testing.T) {
 // BenchmarkLRUCache_Set benchmarks setting values in the cache
 func BenchmarkLRUCache_Set(b *testing.B) {
 	log := logger.New(logger.LevelInfo).WithComponent("benchmark")
-	cache := NewLRUCache[string](1000, log)
+	cache := NewLRUCache[string](1000, 1*time.Second, log)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -43,7 +43,7 @@ func BenchmarkLRUCache_Set(b *testing.B) {
 // BenchmarkLRUCache_Get benchmarks getting values from the cache
 func BenchmarkLRUCache_Get(b *testing.B) {
 	log := logger.New(logger.LevelInfo).WithComponent("benchmark")
-	cache := NewLRUCache[string](1000, log)
+	cache := NewLRUCache[string](1000, 1*time.Second, log)
 
 	// Pre-populate cache
 	for i := 0; i < 1000; i++ {
@@ -61,7 +61,7 @@ func BenchmarkLRUCache_Get(b *testing.B) {
 // BenchmarkLRUCache_GetMiss benchmarks cache misses
 func BenchmarkLRUCache_GetMiss(b *testing.B) {
 	log := logger.New(logger.LevelInfo).WithComponent("benchmark")
-	cache := NewLRUCache[string](1000, log)
+	cache := NewLRUCache[string](1000, 1*time.Second, log)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -73,7 +73,7 @@ func BenchmarkLRUCache_GetMiss(b *testing.B) {
 // BenchmarkLRUCache_SetGetMixed benchmarks mixed operations
 func BenchmarkLRUCache_SetGetMixed(b *testing.B) {
 	log := logger.New(logger.LevelInfo).WithComponent("benchmark")
-	cache := NewLRUCache[string](1000, log)
+	cache := NewLRUCache[string](1000, 1*time.Second, log)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -93,7 +93,7 @@ func BenchmarkLRUCache_DifferentSizes(b *testing.B) {
 	for _, size := range sizes {
 		b.Run(fmt.Sprintf("Size_%d", size), func(b *testing.B) {
 			log := logger.New(logger.LevelInfo).WithComponent("benchmark")
-			cache := NewLRUCache[string](size, log)
+			cache := NewLRUCache[string](size, 1*time.Second, log)
 
 			// Pre-populate
 			for i := 0; i < size; i++ {
@@ -112,7 +112,7 @@ func BenchmarkLRUCache_DifferentSizes(b *testing.B) {
 // Benchmark concurrent access
 func BenchmarkLRUCache_Concurrent(b *testing.B) {
 	log := logger.New(logger.LevelInfo).WithComponent("benchmark")
-	cache := NewLRUCache[string](1000, log)
+	cache := NewLRUCache[string](1000, 1*time.Second, log)
 
 	// Pre-populate
 	for i := 0; i < 1000; i++ {

--- a/pkg/plugin/responsecache/responsecache.go
+++ b/pkg/plugin/responsecache/responsecache.go
@@ -76,7 +76,7 @@ func (p *ResponseCache) ValidateAndSetConfig(conf types.PluginConf) error {
 	}
 	p.config = conf
 	size := conf["size"].(int)
-	p.cache = cache.NewLRUCache[[]byte](size, p.logger)
+	p.cache = cache.NewLRUCache[[]byte](size, 1*time.Second, p.logger)
 	p.logger.Debugf("Initialized ResponseCache plugin with size %d", size)
 	return nil
 }

--- a/pkg/route/matcher.go
+++ b/pkg/route/matcher.go
@@ -32,7 +32,7 @@ func NewPathMatcher(logger *logger.Logger) *PathMatcher {
 		}, 0),
 		prefixRoutes: make(map[string][]*Route),
 		logger:       l,
-		cache:        cache.NewLRUCache[[]*Route](100, l),
+		cache:        cache.NewLRUCache[[]*Route](100, 1*time.Second, l),
 	}
 }
 
@@ -92,7 +92,7 @@ func (pm *PathMatcher) Clear() {
 		routes  []*Route
 	}, 0)
 	pm.prefixRoutes = make(map[string][]*Route)
-	pm.cache = cache.NewLRUCache[[]*Route](100, pm.logger)
+	pm.cache = cache.NewLRUCache[[]*Route](100, 1*time.Second, pm.logger)
 }
 
 type MethodMatcher struct {


### PR DESCRIPTION
Currently one cleanup go routine per key is created for deletion after expiration. This ensures that the keys are deleted immediately after the timer expires. But at the same time, this means a lot of goroutines. At scale this might be a problem theoretically if millions of keys accumulate. 

So I want to move to a janitor based approach. The tradeoff here is that least recently used items will be evicted even if they are not expired when expired items exist. This reduces cache eviction accuracy.

Another solution on this PR can be to add a function makeSpace() which can be called instead of directly calling poptail. But this costs longer cleanup time.

So need a balance between Performance <-----> Accuracy.

```go
func (lru *LRUCache[T]) makeSpace() {
    lru.mx.Lock()
    defer lru.mx.Unlock()
    
    if lru.removeExpiredItems(1) > 0 {
        return // Found and removed at least one expired item
    }
    
    // If no expired items, fall back to LRU eviction
    lru.poptail()
}

func (lru *LRUCache[T]) removeExpiredItems(max int) int {
    now := time.Now().UnixNano()
    removed := 0
    
    // Start from tail (least recently used) and remove expired items
    current := lru.Tail
    for current != nil && removed < max {
        next := current.Left // Save next before potential removal
        if current.expiration > 0 && now > current.expiration {
            lru.log.Debugf("Evicting expired key %s during space creation", current.key)
            lru.pop(current)
            delete(lru.m, current.key)
            removed++
        }
        current = next
    }
    return removed
}
```